### PR TITLE
v0.0.24 – metadata update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modal-lib2",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modal-lib2",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modal-lib2",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "Standalone Angular Modal System",
   "author": "Burt Snyder",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/burtsnyder/modal-lib2.git"
+    "url": "https://github.com/bws9000/modal-lib2.git"
   },
   "bugs": {
-    "url": "https://github.com/burtsnyder/modal-lib2/issues"
+    "url": "https://github.com/bws9000/modal-lib2/issues"
   },
-  "homepage": "https://github.com/burtsnyder/modal-lib2#readme",
+  "homepage": "https://github.com/bws9000/modal-lib2#readme",
   "peerDependencies": {
     "@angular/core": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "@angular/common": "^17.0.0 || ^18.0.0 || ^19.0.0"


### PR DESCRIPTION
Updated package.json to use the correct GitHub handle bws9000 instead of burtsnyder